### PR TITLE
Cast result of malloc() to char*

### DIFF
--- a/napi-macros.h
+++ b/napi-macros.h
@@ -151,7 +151,7 @@
 #define NAPI_UTF8_MALLOC(name, val) \
   size_t name##_size = 0; \
   NAPI_STATUS_THROWS(napi_get_value_string_utf8(env, val, NULL, 0, &name##_size)) \
-  char* name = malloc((name##_size + 1) * sizeof(char)); \
+  char* name = (char*)malloc((name##_size + 1) * sizeof(char)); \
   size_t name##_len; \
   NAPI_STATUS_THROWS(napi_get_value_string_utf8(env, val, name, name##_size + 1, &name##_len)) \
   name[name##_size] = '\0';


### PR DESCRIPTION
Compiler might issue warning and/or error depending on flags.